### PR TITLE
Set an explicit CentOS version for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:6.6
 
 MAINTAINER erickbrower
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER erickbrower
 
 RUN sed -i.bak '/^\[base\]/a exclude=postgresql\*' /etc/yum.repos.d/CentOS-Base.repo
 RUN sed -i.bak '/^\[updates\]/a exclude=postgresql\*' /etc/yum.repos.d/CentOS-Base.repo 
-RUN rpm -Uvh http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-6.noarch.rpm
+RUN rpm -Uvh http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-7.noarch.rpm
 RUN yum install -y postgresql92 postgresql92-server postgresql92-contrib
 RUN su - postgres -c /usr/pgsql-9.2/bin/initdb
 RUN rpm -Uvh http://elgis.argeo.org/repos/6/elgis-release-6-6_0.noarch.rpm


### PR DESCRIPTION
CentOS 7 and upwards don't use `service` anymore. Additionally, postgres 9.2.6 for CentOS no longer exists under the url provided, so I've changed it to 9.2.7.